### PR TITLE
Handle messages with no line

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -19,8 +19,11 @@ module.exports =
           if lintResult.messages.length < 1
             return toReturn
           for data in lintResult.messages
-            line = data.line - 1
-            col = data.col - 1
+            if not data.rollup
+              line = data.line - 1
+              col = data.col - 1
+            else
+              helpers.rangeFromLineNumber(textEditor, 0)
             toReturn.push({
               type: data.type.charAt(0).toUpperCase() + data.type.slice(1),
               text: data.message,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "csslint": "git+https://github.com/AtomLinter/csslint",
-    "atom-linter": "^3.0.0"
+    "atom-linter": "^3.1.0"
   },
   "providedServices": {
     "linter": {


### PR DESCRIPTION
csslint has "rollup" messages that have no line number associated with them. If such a message is encountered place it at the beginning of the file.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-csslint/38)
<!-- Reviewable:end -->
