### PR TITLE
Automatically install linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 linter-csslint
 =========================
 
-This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides an interface to [csslint](https://github.com/CSSLint/csslint). It will be used with files that have the “CSS” or “HTML” syntax.
+This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides
+an interface to [csslint](https://github.com/CSSLint/csslint). It will be used
+with files that have the “CSS” or “HTML” syntax.
 
 ## Installation
-Linter package must be installed in order to use this plugin. If Linter is not installed, please follow the instructions [here](https://github.com/AtomLinter/Linter).
+If the `linter` is not already installed, it will be installed for you to provide
+a UI for the service this package provides.
 
 ### Plugin installation
 ```ShellSession

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,6 +2,9 @@ helpers = require('atom-linter')
 path = require('path')
 
 module.exports =
+  activate: ->
+    require('atom-package-deps').install('linter-csslint')
+
   provideLinter: ->
     helpers = require('atom-linter')
     provider =

--- a/package.json
+++ b/package.json
@@ -13,8 +13,12 @@
   "license": "MIT",
   "dependencies": {
     "csslint": "git+https://github.com/AtomLinter/csslint",
-    "atom-linter": "^3.1.0"
+    "atom-linter": "^3.1.0",
+    "atom-package-deps": "^2.1.3"
   },
+  "package-deps": [
+    "linter"
+  ],
   "providedServices": {
     "linter": {
       "versions": {


### PR DESCRIPTION
Automatically install the `linter` package, if it wasn't installed already.

Closes #43.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-csslint/47)
<!-- Reviewable:end -->
