### PR TITLE
Add linter name

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -8,6 +8,7 @@ module.exports =
   provideLinter: ->
     helpers = require('atom-linter')
     provider =
+      name: 'CSSLint'
       grammarScopes: ['source.css', 'source.html']
       scope: 'file'
       lintOnFly: true


### PR DESCRIPTION
Specifies the linter name, allowing the `linter` package to display it if the user chooses to.