### PR TITLE
Specify current directory

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -17,7 +17,8 @@ module.exports =
         text = textEditor.getText()
         parameters = ['--format=json', '-']
         exec = path.join(__dirname, '..', 'node_modules', 'csslint', 'cli.js')
-        helpers.execNode(exec, parameters, {stdin: text}).then (output) ->
+        cwd = path.dirname(textEditor.getPath())
+        helpers.execNode(exec, parameters, {stdin: text, cwd: cwd}).then (output) ->
           lintResult = JSON.parse(output)
           toReturn = []
           if lintResult.messages.length < 1


### PR DESCRIPTION
Specify the current working directory to the environment that `csslint` is run within, allowing use of `.csslintrc` files.

Fixes #49.