### PR TITLE
Update ESLint to v3.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "coffeelint": "^1.15.0",
     "eslint": "^3.6.1",
-    "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-config-airbnb-base": "^8.0.0",
     "eslint-plugin-import": "^1.7.0"
   },
   "package-deps": [

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "eslintConfig": {
     "extends": "airbnb-base",
     "rules": {
-      "global-require": 0,
+      "global-require": "off",
       "import/no-unresolved": [
-        2,
+        "error",
         {
           "ignore": [
             "atom"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "coffeelint": "^1.15.0",
     "eslint": "^3.6.1",
     "eslint-config-airbnb-base": "^8.0.0",
-    "eslint-plugin-import": "^1.7.0"
+    "eslint-plugin-import": "^1.16.0"
   },
   "package-deps": [
     "linter"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "coffeelint": "^1.15.0",
-    "eslint": "^2.9.0",
+    "eslint": "^3.6.1",
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-import": "^1.7.0"
   },

--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "env": {
-    "jasmine": true,
-    "atomtest": true
-  }
-}

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  env: {
+    jasmine: true,
+    atomtest: true
+  }
+};

--- a/spec/linter-csslint-spec.js
+++ b/spec/linter-csslint-spec.js
@@ -26,7 +26,7 @@ describe('The csslint provider for Linter', () => {
     let editor = null;
     beforeEach(() =>
       waitsForPromise(() =>
-        atom.workspace.open(badPath).then(openEditor => { editor = openEditor; })
+        atom.workspace.open(badPath).then((openEditor) => { editor = openEditor; })
       )
     );
 
@@ -40,7 +40,7 @@ describe('The csslint provider for Linter', () => {
 
     it('verifies the first message', () =>
       waitsForPromise(() =>
-        lint(editor).then(messages => {
+        lint(editor).then((messages) => {
           expect(messages[0].type).toBe('Warning');
           expect(messages[0].text).toBe('Rule is empty.');
           expect(messages[0].filePath).toBe(badPath);
@@ -54,7 +54,7 @@ describe('The csslint provider for Linter', () => {
     let editor = null;
     beforeEach(() =>
       waitsForPromise(() =>
-        atom.workspace.open(invalidPath).then(openEditor => { editor = openEditor; })
+        atom.workspace.open(invalidPath).then((openEditor) => { editor = openEditor; })
       )
     );
 
@@ -68,7 +68,7 @@ describe('The csslint provider for Linter', () => {
 
     it('verifies the message', () =>
       waitsForPromise(() =>
-        lint(editor).then(messages => {
+        lint(editor).then((messages) => {
           expect(messages[0].type).toBe('Error');
           expect(messages[0].text).toBe('Unexpected token \'}\' at line 1, col 1.');
           expect(messages[0].filePath).toBe(invalidPath);
@@ -102,7 +102,7 @@ describe('The csslint provider for Linter', () => {
     atom.project.addPath(projectPath);
     waitsForPromise(() =>
       atom.workspace.open(projectBadPath).then(editor =>
-        lint(editor).then(messages => {
+        lint(editor).then((messages) => {
           expect(messages[0].type).toBeDefined();
           expect(messages[0].type).toEqual('Error');
           expect(messages[0].text).toBeDefined();


### PR DESCRIPTION
Updates to:

* `eslint@3.6.1`
* `eslint-config-airbnb-base@8.0.0`
* `eslint-plugin-import@1.16.0`

Fixes lint issues exposed by the updates, and updates the configuration format.

Closes #143.
Closes #145.