### PR TITLE
Get bug fixes in csslint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     }
   },
   "dependencies": {
-    "atomlinter-csslint": "0.10.0",
+    "atomlinter-csslint": "~0.10.0",
     "atom-linter": "^8.0.0",
     "atom-package-deps": "^4.0.1"
   },


### PR DESCRIPTION
Since there's a `0.10.1` release in [`atomlinter-csslint`](https://github.com/AtomLinter/csslint), we could change the dependency to grab anything up to `0.10.x` rather than explicitly peg to `0.10.0`