### PR TITLE
fix: error on CSSLint stderr

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -23,6 +23,15 @@ const loadDeps = () => {
   }
 };
 
+const getCheckNotificationDetails = checkDetail =>
+  (notification) => {
+    const { detail } = notification.getOptions();
+    if (detail === checkDetail) {
+      return true;
+    }
+    return false;
+  };
+
 export default {
   activate() {
     this.idleCallbacks = new Set();
@@ -47,11 +56,15 @@ export default {
       'linter-csslint.executablePath',
       (value) => { this.executablePath = value; },
     ));
+
+    this.activeNotifications = new Set();
   },
 
   deactivate() {
     this.idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID));
     this.idleCallbacks.clear();
+    this.activeNotifications.forEach(notification => notification.dismiss());
+    this.activeNotifications.clear();
     this.subscriptions.dispose();
   },
 
@@ -90,7 +103,34 @@ export default {
 
         const execPath = this.determineExecPath(this.executablePath, projectPath);
 
-        const output = await helpers.exec(execPath, parameters, execOptions);
+        let output;
+        try {
+          output = await helpers.exec(execPath, parameters, execOptions);
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.error(e);
+
+          // Check if the notification is currently showing to the user
+          const checkNotificationDetails = getCheckNotificationDetails(e.message);
+          if (Array.from(this.activeNotifications).some(checkNotificationDetails)) {
+            // This message is still showing to the user!
+            return null;
+          }
+
+          // Notify the user
+          const message = 'linter-csslint:: Error while running CSSLint!';
+          const options = {
+            detail: e.message,
+            dismissable: true,
+          };
+          const notification = atom.notifications.addError(message, options);
+          this.activeNotifications.add(notification);
+          // Remove it when the user closes the notification
+          notification.onDidDismiss(() => this.activeNotifications.delete(notification));
+
+          // Don't update any current results
+          return null;
+        }
 
         if (textEditor.getText() !== text) {
           // The editor contents have changed, tell Linter not to update

--- a/spec/linter-csslint-spec.js
+++ b/spec/linter-csslint-spec.js
@@ -114,4 +114,35 @@ describe('The CSSLint provider for Linter', () => {
       expect(foundPath).toBe('foobar');
     });
   });
+
+  describe('handles invalid CSSLint paths', () => {
+    let editor;
+    const message = 'linter-csslint:: Error while running CSSLint!';
+    const detail = 'Failed to spawn command `foo`. Make sure `foo` is installed and on your PATH';
+
+    beforeEach(async () => {
+      atom.config.set('linter-csslint.executablePath', 'foo');
+
+      editor = await atom.workspace.open(goodPath);
+      await lint(editor);
+    });
+
+    it('tells the user when they specify an invalid CSSLint path', async () => {
+      const currentNotifications = atom.notifications.getNotifications();
+
+      expect(currentNotifications.length).toBe(1);
+      expect(currentNotifications[0].getMessage()).toBe(message);
+      expect(currentNotifications[0].getOptions().detail).toBe(detail);
+    });
+
+    it('only notifies for invalid paths once', async () => {
+      // Run the lint again to check the path twice
+      await lint(editor);
+      const currentNotifications = atom.notifications.getNotifications();
+
+      expect(currentNotifications.length).toBe(1);
+      expect(currentNotifications[0].getMessage()).toBe(message);
+      expect(currentNotifications[0].getOptions().detail).toBe(detail);
+    });
+  });
 });


### PR DESCRIPTION
If CSSLint returns text on `stderr`, or more likely a message is thrown for a miss-configured path to CSSLint, show this message to the user instead of attempting to go on and parse the (empty) output.

Messages are shown until the user interacts with them, but are deduplicated so they are only actively shown once.

Fixes #181.
Fixes #189.