### PR TITLE
Remove HTML from supported types

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -71,7 +71,7 @@ export default {
   provideLinter() {
     return {
       name: 'CSSLint',
-      grammarScopes: ['source.css', 'source.html'],
+      grammarScopes: ['source.css'],
       scope: 'file',
       lintsOnChange: false,
       lint: async (textEditor) => {


### PR DESCRIPTION
This was added way back in the original re-write in 72bb9717 with no justification, and has no specs backing it up to even see if it works. Since CSSLint makes no mention of this even being a feature this should just be removed.

Fixes #207.