### PR TITLE
Handle superseded runs

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -132,6 +132,11 @@ export default {
           return null;
         }
 
+        if (output === null) {
+          // Another run has superseded this run
+          return null;
+        }
+
         if (textEditor.getText() !== text) {
           // The editor contents have changed, tell Linter not to update
           return null;


### PR DESCRIPTION
Check that the result of the execution isn't null, and if it was return `null` back to the consumer since another run had to have been started with newer content than the one currently running.

Fixes #214.